### PR TITLE
Add SignUp component with CSS styling

### DIFF
--- a/src/SignUp.css
+++ b/src/SignUp.css
@@ -1,5 +1,9 @@
-/* Importar Roboto font */
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
+/* Importar Roboto font con todos los pesos necesarios */
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap");
+
+* {
+  box-sizing: border-box;
+}
 
 .signup-container {
   min-height: 100vh;
@@ -7,31 +11,87 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  background: #f5f5f5;
+  justify-content: flex-start;
+  background: #f8f9fa;
   padding: 20px;
-  box-sizing: border-box;
   font-family:
     "Roboto",
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
     sans-serif;
+  position: relative;
+}
+
+/* Indicador de pasos */
+.step-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 32px;
+  margin-top: 20px;
+}
+
+.step-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.step-number {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  font-size: 14px;
+  border: 2px solid #e0e0e0;
+  color: #999;
+  background: #fff;
+  transition: all 0.3s ease;
+}
+
+.step-item.active .step-number {
+  background: #13a688;
+  border-color: #13a688;
+  color: #fff;
+}
+
+.step-label {
+  font-size: 12px;
+  color: #999;
+  font-weight: 400;
+  text-align: center;
+}
+
+.step-item.active .step-label {
+  color: #13a688;
+  font-weight: 500;
+}
+
+.step-divider {
+  width: 40px;
+  height: 2px;
+  background: #e0e0e0;
+  margin: 0 8px;
 }
 
 .signup-card {
   width: 100%;
   max-width: 400px;
   background: #fff;
-  border-radius: 10px;
-  box-shadow: 0px 12px 40px 0px rgba(0, 0, 0, 0.12);
-  padding: 40px;
-  box-sizing: border-box;
+  border-radius: 12px;
+  box-shadow: 0px 8px 32px rgba(0, 0, 0, 0.08);
+  padding: 32px;
+  position: relative;
 }
 
 .signup-header {
   text-align: center;
-  margin-bottom: 40px;
+  margin-bottom: 32px;
 }
 
 .doctocliq-logo {
@@ -39,37 +99,106 @@
 }
 
 .logo-text {
-  font-size: 24px;
+  font-size: 28px;
   font-weight: 700;
   color: #1e212a;
-  letter-spacing: 1px;
+  letter-spacing: 2px;
   margin-bottom: 4px;
+  font-family: "Roboto", sans-serif;
 }
 
 .logo-subtitle {
-  font-size: 12px;
+  font-size: 13px;
   color: #65676e;
   font-weight: 400;
+  letter-spacing: 0.5px;
 }
 
 .welcome-title {
-  font-size: 23px;
+  font-size: 24px;
   font-weight: 400;
   color: #1e212a;
-  margin: 0 0 16px 0;
-  line-height: 36px;
+  margin: 0 0 12px 0;
+  line-height: 1.3;
+  font-family: "Roboto", sans-serif;
 }
 
 .signup-subtitle {
-  font-size: 14px;
-  color: #1e212a;
+  font-size: 15px;
+  color: #65676e;
   margin: 0;
   font-weight: 400;
-  line-height: 21px;
+}
+
+/* Sección social */
+.social-section {
+  margin-bottom: 24px;
+}
+
+.social-title {
+  text-align: center;
+  font-size: 14px;
+  color: #1e212a;
+  margin-bottom: 16px;
+  font-weight: 500;
+}
+
+.social-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.social-button {
+  width: 100%;
+  height: 48px;
+  border: 1.5px solid #e8e9ea;
+  border-radius: 8px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 15px;
+  color: #1e212a;
+  font-family: "Roboto", sans-serif;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  gap: 12px;
+}
+
+.social-button:hover {
+  border-color: #13a688;
+  background: #f8f9fa;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.social-button svg {
+  flex-shrink: 0;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  margin: 24px 0;
+}
+
+.divider-line {
+  flex: 1;
+  height: 1px;
+  background: #e8e9ea;
+}
+
+.divider-text {
+  margin: 0 16px;
+  font-size: 13px;
+  color: #65676e;
+  font-weight: 500;
 }
 
 .signup-form {
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 }
 
 .form-group {
@@ -84,32 +213,43 @@
 .form-input {
   width: 100%;
   height: 52px;
-  padding: 17px;
-  border: 1px solid #c9cace;
-  border-radius: 5px;
+  padding: 16px;
+  border: 1.5px solid #e8e9ea;
+  border-radius: 8px;
   background: #fff;
   font-family: "Roboto", sans-serif;
-  font-size: 16px;
-  color: #000;
-  box-sizing: border-box;
+  font-size: 15px;
+  color: #1e212a;
   outline: none;
-  transition: border-color 0.2s ease;
+  transition: all 0.2s ease;
 }
 
-.form-input:focus {
+.form-input:focus,
+.form-input:not(:placeholder-shown) {
   border-color: #13a688;
+  box-shadow: 0 0 0 3px rgba(19, 166, 136, 0.1);
+}
+
+.form-input:focus + .floating-label,
+.form-input:not(:placeholder-shown) + .floating-label {
+  top: -8px;
+  font-size: 12px;
+  color: #13a688;
+  font-weight: 500;
 }
 
 .floating-label {
   position: absolute;
-  top: -9px;
-  left: 9px;
+  top: 16px;
+  left: 16px;
   background: #fff;
-  padding: 0 5px;
-  font-size: 14px;
+  padding: 0 6px;
+  font-size: 15px;
   color: #65676e;
   font-weight: 400;
   pointer-events: none;
+  transition: all 0.2s ease;
+  font-family: "Roboto", sans-serif;
 }
 
 .password-wrapper {
@@ -125,48 +265,95 @@
   border: none;
   cursor: pointer;
   padding: 8px;
-  border-radius: 3px;
+  border-radius: 6px;
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background-color 0.2s ease;
 }
 
 .password-toggle:hover {
   background: rgba(0, 0, 0, 0.05);
 }
 
-.password-requirements {
-  border: 1px solid #c9cace;
-  border-radius: 3px;
-  padding: 15px 17px;
-  margin-bottom: 24px;
+/* Tooltip de contraseña */
+.password-tooltip {
+  position: absolute;
+  right: -320px;
+  top: 0;
+  z-index: 1000;
+  opacity: 0;
+  animation: fadeInTooltip 0.2s ease forwards;
 }
 
-.requirements-title {
-  font-size: 14px;
+@keyframes fadeInTooltip {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.tooltip-content {
+  background: #fff;
+  border: 1.5px solid #e8e9ea;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  min-width: 280px;
+  position: relative;
+}
+
+.tooltip-content::before {
+  content: "";
+  position: absolute;
+  left: -8px;
+  top: 20px;
+  width: 0;
+  height: 0;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-right: 8px solid #e8e9ea;
+}
+
+.tooltip-content::after {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 21px;
+  width: 0;
+  height: 0;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  border-right: 7px solid #fff;
+}
+
+.tooltip-title {
+  font-size: 13px;
   color: #1e212a;
   margin: 0 0 12px 0;
-  font-weight: 400;
-  line-height: 20px;
+  font-weight: 500;
 }
 
-.requirements-list {
+.tooltip-list {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.requirements-list li {
+.tooltip-list li {
   display: flex;
   align-items: flex-start;
-  margin-bottom: 8px;
-  font-size: 14px;
-  line-height: 20px;
+  margin-bottom: 6px;
+  font-size: 12px;
   position: relative;
-  padding-left: 24px;
+  padding-left: 20px;
 }
 
-.requirements-list li:last-child {
+.tooltip-list li:last-child {
   margin-bottom: 0;
 }
 
@@ -174,142 +361,165 @@
   position: absolute;
   left: 0;
   top: 0;
-  width: 10px;
-  height: 10px;
-  font-size: 14px;
-  line-height: 20px;
+  width: 12px;
+  height: 12px;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.requirements-list .valid {
+.tooltip-list .valid {
   color: #13a688;
 }
 
-.requirements-list .valid .checkmark {
+.tooltip-list .valid .checkmark {
   color: #13a688;
 }
 
-.requirements-list .invalid {
-  color: #65676e;
+.tooltip-list .invalid {
+  color: #999;
 }
 
-.requirements-list .invalid .checkmark {
-  color: #c9cace;
+.tooltip-list .invalid .checkmark {
+  color: #ddd;
 }
 
-.sub-requirements {
+.sub-tooltip-list {
   list-style: none;
   padding: 0;
-  margin: 8px 0 0 0;
-  padding-left: 24px;
+  margin: 6px 0 0 0;
+  padding-left: 16px;
 }
 
-.sub-requirements li {
-  margin-bottom: 8px;
-  padding-left: 24px;
+.sub-tooltip-list li {
+  margin-bottom: 4px;
+  padding-left: 20px;
 }
 
+/* Checkbox Recuérdame */
+.remember-me {
+  margin-bottom: 24px;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 12px;
+  position: relative;
+}
+
+.checkbox-input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.checkbox-custom {
+  width: 18px;
+  height: 18px;
+  border: 2px solid #e8e9ea;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  background: #fff;
+}
+
+.checkbox-input:checked + .checkbox-custom {
+  background: #13a688;
+  border-color: #13a688;
+}
+
+.checkbox-input:checked + .checkbox-custom::after {
+  content: "✓";
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.checkbox-label {
+  font-size: 14px;
+  color: #1e212a;
+  font-weight: 400;
+  user-select: none;
+}
+
+/* Botón Continue mejorado */
 .continue-button {
   width: 100%;
   height: 52px;
-  background: #008ba1;
-  color: #fff;
+  background: #e8e9ea;
+  color: #999;
   border: none;
-  border-radius: 3px;
-  font-size: 16px;
-  font-weight: 400;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 500;
   font-family: "Roboto", sans-serif;
-  cursor: pointer;
-  line-height: 16px;
-  transition: all 0.2s ease;
-}
-
-.continue-button:hover:not(:disabled) {
-  background: #007488;
-}
-
-.continue-button:disabled {
-  background: #c9cace;
   cursor: not-allowed;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.continue-button.active {
+  background: #13a688;
+  color: #fff;
+  cursor: pointer;
+  transform: translateY(0);
+  box-shadow: 0 4px 12px rgba(19, 166, 136, 0.3);
+}
+
+.continue-button.active:hover {
+  background: #0f8a6f;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(19, 166, 136, 0.4);
+}
+
+.continue-button.active svg {
+  animation: slideRight 0.3s ease;
+}
+
+@keyframes slideRight {
+  from {
+    transform: translateX(-5px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 .login-link {
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: 0;
   font-size: 14px;
-  color: #1e212a;
-  line-height: 14px;
+  color: #65676e;
 }
 
 .link-button {
   background: none;
   border: none;
-  color: #635dff;
-  font-weight: 700;
+  color: #13a688;
+  font-weight: 600;
   font-size: 14px;
   cursor: pointer;
   font-family: "Roboto", sans-serif;
-  line-height: 21px;
   text-decoration: none;
   padding: 0;
+  transition: color 0.2s ease;
 }
 
 .link-button:hover {
+  color: #0f8a6f;
   text-decoration: underline;
-}
-
-.divider {
-  display: flex;
-  align-items: center;
-  margin-bottom: 24px;
-}
-
-.divider-line {
-  flex: 1;
-  height: 1px;
-  background: #c9cace;
-}
-
-.divider-text {
-  margin: 0 12px;
-  font-size: 12px;
-  color: #1e212a;
-  text-transform: uppercase;
-  font-weight: 400;
-}
-
-.social-buttons {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.social-button {
-  width: 100%;
-  height: 52px;
-  border: 1px solid #c9cace;
-  border-radius: 3px;
-  background: #fff;
-  display: flex;
-  align-items: center;
-  padding: 16px 17px;
-  cursor: pointer;
-  font-size: 16px;
-  color: #1e212a;
-  font-family: "Roboto", sans-serif;
-  font-weight: 400;
-  line-height: 16px;
-  transition: all 0.2s ease;
-  box-sizing: border-box;
-}
-
-.social-button:hover {
-  border-color: #999;
-  background: #f9f9f9;
-}
-
-.social-button svg {
-  margin-right: 16px;
-  flex-shrink: 0;
 }
 
 .navigation-buttons {
@@ -323,19 +533,21 @@
 }
 
 .nav-button {
-  background: none;
-  border: none;
-  font-weight: bold;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  font-weight: 500;
   cursor: pointer;
   padding: 8px 16px;
   font-family: "Roboto", sans-serif;
   color: #1e212a;
-  border-radius: 4px;
-  transition: background-color 0.2s ease;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+  backdrop-filter: blur(8px);
 }
 
 .nav-button:hover {
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .nav-button:disabled {
@@ -344,10 +556,50 @@
 }
 
 .nav-button:disabled:hover {
-  background: none;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
 }
 
 /* Responsive Design */
+@media (max-width: 768px) {
+  .password-tooltip {
+    position: fixed;
+    right: 20px;
+    left: 20px;
+    top: auto;
+    bottom: 100px;
+    z-index: 1001;
+  }
+
+  .tooltip-content {
+    min-width: auto;
+    width: 100%;
+  }
+
+  .tooltip-content::before,
+  .tooltip-content::after {
+    display: none;
+  }
+
+  .step-indicator {
+    margin-bottom: 24px;
+  }
+
+  .step-divider {
+    width: 24px;
+  }
+
+  .step-label {
+    font-size: 10px;
+  }
+
+  .step-number {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+}
+
 @media (max-width: 480px) {
   .signup-container {
     padding: 16px;
@@ -358,11 +610,11 @@
   }
 
   .signup-header {
-    margin-bottom: 32px;
+    margin-bottom: 24px;
   }
 
   .welcome-title {
-    font-size: 20px;
+    font-size: 22px;
   }
 
   .form-input {
@@ -375,6 +627,11 @@
     left: auto;
     right: auto;
     margin-top: 20px;
+    background: none;
+  }
+
+  .step-indicator {
+    transform: scale(0.9);
   }
 }
 
@@ -386,56 +643,77 @@
   .social-button {
     font-size: 14px;
   }
+
+  .step-indicator {
+    transform: scale(0.8);
+  }
 }
 
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .signup-container {
-    background: #1a1a1a;
+    background: #121212;
   }
 
   .signup-card {
-    background: #2a2a2a;
+    background: #1e1e1e;
     color: #fff;
   }
 
   .logo-text,
   .welcome-title,
   .signup-subtitle,
-  .requirements-title,
-  .login-link,
-  .divider-text {
+  .social-title,
+  .checkbox-label,
+  .login-link {
     color: #fff;
   }
 
   .form-input {
-    background: #333;
-    border-color: #555;
+    background: #2a2a2a;
+    border-color: #404040;
     color: #fff;
   }
 
   .floating-label {
-    background: #2a2a2a;
+    background: #1e1e1e;
     color: #999;
   }
 
-  .password-requirements {
-    border-color: #555;
-    background: #333;
+  .form-input:focus + .floating-label,
+  .form-input:not(:placeholder-shown) + .floating-label {
+    color: #13a688;
   }
 
   .social-button {
-    background: #333;
-    border-color: #555;
+    background: #2a2a2a;
+    border-color: #404040;
     color: #fff;
   }
 
   .social-button:hover {
-    background: #444;
-    border-color: #666;
+    background: #333;
+    border-color: #13a688;
+  }
+
+  .tooltip-content {
+    background: #2a2a2a;
+    border-color: #404040;
+    color: #fff;
+  }
+
+  .checkbox-custom {
+    background: #2a2a2a;
+    border-color: #404040;
   }
 
   .nav-button {
+    background: rgba(30, 30, 30, 0.9);
+    border-color: rgba(255, 255, 255, 0.1);
     color: #fff;
+  }
+
+  .nav-button:hover {
+    background: rgba(30, 30, 30, 1);
   }
 }

--- a/src/SignUp.css
+++ b/src/SignUp.css
@@ -1,0 +1,441 @@
+/* Importar Roboto font */
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
+
+.signup-container {
+  min-height: 100vh;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  padding: 20px;
+  box-sizing: border-box;
+  font-family:
+    "Roboto",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.signup-card {
+  width: 100%;
+  max-width: 400px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0px 12px 40px 0px rgba(0, 0, 0, 0.12);
+  padding: 40px;
+  box-sizing: border-box;
+}
+
+.signup-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.doctocliq-logo {
+  margin-bottom: 24px;
+}
+
+.logo-text {
+  font-size: 24px;
+  font-weight: 700;
+  color: #1e212a;
+  letter-spacing: 1px;
+  margin-bottom: 4px;
+}
+
+.logo-subtitle {
+  font-size: 12px;
+  color: #65676e;
+  font-weight: 400;
+}
+
+.welcome-title {
+  font-size: 23px;
+  font-weight: 400;
+  color: #1e212a;
+  margin: 0 0 16px 0;
+  line-height: 36px;
+}
+
+.signup-subtitle {
+  font-size: 14px;
+  color: #1e212a;
+  margin: 0;
+  font-weight: 400;
+  line-height: 21px;
+}
+
+.signup-form {
+  margin-bottom: 20px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.input-wrapper {
+  position: relative;
+}
+
+.form-input {
+  width: 100%;
+  height: 52px;
+  padding: 17px;
+  border: 1px solid #c9cace;
+  border-radius: 5px;
+  background: #fff;
+  font-family: "Roboto", sans-serif;
+  font-size: 16px;
+  color: #000;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.form-input:focus {
+  border-color: #13a688;
+}
+
+.floating-label {
+  position: absolute;
+  top: -9px;
+  left: 9px;
+  background: #fff;
+  padding: 0 5px;
+  font-size: 14px;
+  color: #65676e;
+  font-weight: 400;
+  pointer-events: none;
+}
+
+.password-wrapper {
+  position: relative;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.password-toggle:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.password-requirements {
+  border: 1px solid #c9cace;
+  border-radius: 3px;
+  padding: 15px 17px;
+  margin-bottom: 24px;
+}
+
+.requirements-title {
+  font-size: 14px;
+  color: #1e212a;
+  margin: 0 0 12px 0;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+.requirements-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.requirements-list li {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 8px;
+  font-size: 14px;
+  line-height: 20px;
+  position: relative;
+  padding-left: 24px;
+}
+
+.requirements-list li:last-child {
+  margin-bottom: 0;
+}
+
+.checkmark {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 10px;
+  height: 10px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.requirements-list .valid {
+  color: #13a688;
+}
+
+.requirements-list .valid .checkmark {
+  color: #13a688;
+}
+
+.requirements-list .invalid {
+  color: #65676e;
+}
+
+.requirements-list .invalid .checkmark {
+  color: #c9cace;
+}
+
+.sub-requirements {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0 0;
+  padding-left: 24px;
+}
+
+.sub-requirements li {
+  margin-bottom: 8px;
+  padding-left: 24px;
+}
+
+.continue-button {
+  width: 100%;
+  height: 52px;
+  background: #008ba1;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  font-size: 16px;
+  font-weight: 400;
+  font-family: "Roboto", sans-serif;
+  cursor: pointer;
+  line-height: 16px;
+  transition: all 0.2s ease;
+}
+
+.continue-button:hover:not(:disabled) {
+  background: #007488;
+}
+
+.continue-button:disabled {
+  background: #c9cace;
+  cursor: not-allowed;
+}
+
+.login-link {
+  text-align: center;
+  margin-bottom: 24px;
+  font-size: 14px;
+  color: #1e212a;
+  line-height: 14px;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: #635dff;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  font-family: "Roboto", sans-serif;
+  line-height: 21px;
+  text-decoration: none;
+  padding: 0;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.divider-line {
+  flex: 1;
+  height: 1px;
+  background: #c9cace;
+}
+
+.divider-text {
+  margin: 0 12px;
+  font-size: 12px;
+  color: #1e212a;
+  text-transform: uppercase;
+  font-weight: 400;
+}
+
+.social-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.social-button {
+  width: 100%;
+  height: 52px;
+  border: 1px solid #c9cace;
+  border-radius: 3px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  padding: 16px 17px;
+  cursor: pointer;
+  font-size: 16px;
+  color: #1e212a;
+  font-family: "Roboto", sans-serif;
+  font-weight: 400;
+  line-height: 16px;
+  transition: all 0.2s ease;
+  box-sizing: border-box;
+}
+
+.social-button:hover {
+  border-color: #999;
+  background: #f9f9f9;
+}
+
+.social-button svg {
+  margin-right: 16px;
+  flex-shrink: 0;
+}
+
+.navigation-buttons {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  right: 16px;
+  display: flex;
+  justify-content: space-between;
+  z-index: 1000;
+}
+
+.nav-button {
+  background: none;
+  border: none;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 8px 16px;
+  font-family: "Roboto", sans-serif;
+  color: #1e212a;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.nav-button:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.nav-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.nav-button:disabled:hover {
+  background: none;
+}
+
+/* Responsive Design */
+@media (max-width: 480px) {
+  .signup-container {
+    padding: 16px;
+  }
+
+  .signup-card {
+    padding: 24px 20px;
+  }
+
+  .signup-header {
+    margin-bottom: 32px;
+  }
+
+  .welcome-title {
+    font-size: 20px;
+  }
+
+  .form-input {
+    font-size: 16px; /* Prevent zoom on iOS */
+  }
+
+  .navigation-buttons {
+    position: relative;
+    top: auto;
+    left: auto;
+    right: auto;
+    margin-top: 20px;
+  }
+}
+
+@media (max-width: 360px) {
+  .signup-card {
+    padding: 20px 16px;
+  }
+
+  .social-button {
+    font-size: 14px;
+  }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .signup-container {
+    background: #1a1a1a;
+  }
+
+  .signup-card {
+    background: #2a2a2a;
+    color: #fff;
+  }
+
+  .logo-text,
+  .welcome-title,
+  .signup-subtitle,
+  .requirements-title,
+  .login-link,
+  .divider-text {
+    color: #fff;
+  }
+
+  .form-input {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+
+  .floating-label {
+    background: #2a2a2a;
+    color: #999;
+  }
+
+  .password-requirements {
+    border-color: #555;
+    background: #333;
+  }
+
+  .social-button {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+
+  .social-button:hover {
+    background: #444;
+    border-color: #666;
+  }
+
+  .nav-button {
+    color: #fff;
+  }
+}

--- a/src/SignUp.jsx
+++ b/src/SignUp.jsx
@@ -1,13 +1,254 @@
-import React from "react";
+import React, { useState } from "react";
+import "./SignUp.css";
 
-const SignUp = ({ goTo, goHome }) => (
-  <div style={{ minHeight: '100vh', width: '100vw', display: 'flex', flexDirection: 'column' }}>
-    <header style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', padding: 16, position: 'relative' }}>
-      <button onClick={goHome} style={{ fontWeight: 'bold', position: 'absolute', left: 16 }}>Inicio</button>
-      <button onClick={() => goTo('verify_mail')} style={{ fontWeight: 'bold', marginLeft: 'auto' }}>Siguiente</button>
-    </header>
-    <main style={{ flex: 1, width: '100vw', display: 'flex', alignItems: 'center', justifyContent: 'center' }}></main>
-  </div>
-);
+const SignUp = ({ goTo, goHome }) => {
+  const [email, setEmail] = useState("lopez.vanessa@pucp.pe");
+  const [password, setPassword] = useState("Lc0de#2020");
+  const [showPassword, setShowPassword] = useState(false);
+
+  // Validaciones de contraseña
+  const validatePassword = (password) => {
+    const validations = {
+      minLength: password.length >= 8,
+      hasLowercase: /[a-z]/.test(password),
+      hasUppercase: /[A-Z]/.test(password),
+      hasNumbers: /[0-9]/.test(password),
+      hasSpecialChars: /[!@#$%^&*(),.?":{}|<>]/.test(password),
+    };
+
+    const passedCount = Object.values(validations).filter(Boolean).length - 1; // Exclude minLength
+    validations.hasThreeRequirements = passedCount >= 3;
+
+    return validations;
+  };
+
+  const passwordValidations = validatePassword(password);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (
+      passwordValidations.minLength &&
+      passwordValidations.hasThreeRequirements
+    ) {
+      goTo("verify_mail");
+    }
+  };
+
+  const handleSocialLogin = (provider) => {
+    console.log(`Iniciando sesión con ${provider}`);
+    // Aquí iría la lógica de autenticación social
+  };
+
+  return (
+    <div className="signup-container">
+      <div className="signup-card">
+        <div className="signup-header">
+          <div className="doctocliq-logo">
+            <div className="logo-text">DOCTOCLIQ</div>
+            <div className="logo-subtitle">Rentabiliza tu consultorio</div>
+          </div>
+          <h1 className="welcome-title">Welcome</h1>
+          <p className="signup-subtitle">Sign Up to Doctocliq</p>
+        </div>
+
+        <form className="signup-form" onSubmit={handleSubmit}>
+          <div className="form-group">
+            <div className="input-wrapper">
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="form-input"
+                required
+              />
+              <label className="floating-label">Email address*</label>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <div className="input-wrapper password-wrapper">
+              <input
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="form-input"
+                required
+              />
+              <label className="floating-label">Password*</label>
+              <button
+                type="button"
+                className="password-toggle"
+                onClick={() => setShowPassword(!showPassword)}
+                aria-label={
+                  showPassword ? "Ocultar contraseña" : "Mostrar contraseña"
+                }
+              >
+                <svg
+                  width="18"
+                  height="13"
+                  viewBox="0 0 19 14"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M9.25 12.5C12.38 12.5 14.982 10.712 17.106 7C14.982 3.288 12.38 1.5 9.25 1.5C6.12 1.5 3.518 3.288 1.394 7C3.518 10.712 6.12 12.5 9.25 12.5ZM9.25 0.5C12.917 0.5 15.917 2.667 18.25 7C15.917 11.333 12.917 13.5 9.25 13.5C5.583 13.5 2.583 11.333 0.25 7C2.583 2.667 5.583 0.5 9.25 0.5ZM9.25 9.5C9.91304 9.5 10.5489 9.23661 11.0178 8.76777C11.4866 8.29893 11.75 7.66304 11.75 7C11.75 6.33696 11.4866 5.70107 11.0178 5.23223C10.5489 4.76339 9.91304 4.5 9.25 4.5C8.58696 4.5 7.95107 4.76339 7.48223 5.23223C7.01339 5.70107 6.75 6.33696 6.75 7C6.75 7.66304 7.01339 8.29893 7.48223 8.76777C7.95107 9.23661 8.58696 9.5 9.25 9.5V9.5ZM9.25 10.5C8.79037 10.5 8.33525 10.4095 7.91061 10.2336C7.48597 10.0577 7.10013 9.79988 6.77513 9.47487C6.45012 9.14987 6.19231 8.76403 6.01642 8.33939C5.84053 7.91475 5.75 7.45963 5.75 7C5.75 6.54037 5.84053 6.08525 6.01642 5.66061C6.19231 5.23597 6.45012 4.85013 6.77513 4.52513C7.10013 4.20012 7.48597 3.94231 7.91061 3.76642C8.33525 3.59053 8.79037 3.5 9.25 3.5C10.1783 3.5 11.0685 3.86875 11.7249 4.52513C12.3813 5.1815 12.75 6.07174 12.75 7C12.75 7.92826 12.3813 8.8185 11.7249 9.47487C11.0685 10.1313 10.1783 10.5 9.25 10.5Z"
+                    fill="#5C677D"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div className="password-requirements">
+            <p className="requirements-title">Your password must contain:</p>
+            <ul className="requirements-list">
+              <li
+                className={passwordValidations.minLength ? "valid" : "invalid"}
+              >
+                <span className="checkmark">✓</span>
+                At least 8 characters
+              </li>
+              <li
+                className={
+                  passwordValidations.hasThreeRequirements ? "valid" : "invalid"
+                }
+              >
+                <span className="checkmark">✓</span>
+                At least 3 of the following:
+              </li>
+              <ul className="sub-requirements">
+                <li
+                  className={
+                    passwordValidations.hasLowercase ? "valid" : "invalid"
+                  }
+                >
+                  <span className="checkmark">✓</span>
+                  Lower case letters (a-z)
+                </li>
+                <li
+                  className={
+                    passwordValidations.hasUppercase ? "valid" : "invalid"
+                  }
+                >
+                  <span className="checkmark">✓</span>
+                  Upper case letters (A-Z)
+                </li>
+                <li
+                  className={
+                    passwordValidations.hasNumbers ? "valid" : "invalid"
+                  }
+                >
+                  <span className="checkmark">✓</span>
+                  Numbers (0-9)
+                </li>
+                <li
+                  className={
+                    passwordValidations.hasSpecialChars ? "valid" : "invalid"
+                  }
+                >
+                  <span className="checkmark">✓</span>
+                  Special characters (e.g. !@#$%^&*)
+                </li>
+              </ul>
+            </ul>
+          </div>
+
+          <button
+            type="submit"
+            className="continue-button"
+            disabled={
+              !passwordValidations.minLength ||
+              !passwordValidations.hasThreeRequirements
+            }
+          >
+            Continue
+          </button>
+        </form>
+
+        <div className="login-link">
+          <span>Already have an account? </span>
+          <button className="link-button" onClick={() => goTo("login")}>
+            Log in
+          </button>
+        </div>
+
+        <div className="divider">
+          <span className="divider-line"></span>
+          <span className="divider-text">OR</span>
+          <span className="divider-line"></span>
+        </div>
+
+        <div className="social-buttons">
+          <button
+            className="social-button"
+            onClick={() => handleSocialLogin("Google")}
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 21 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0.25 15.4167V4.58334L7.33333 10L0.25 15.4167Z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M0.25 4.58333L7.33333 10L10.25 7.45833L20.25 5.83333V0H0.25V4.58333Z"
+                fill="#EA4335"
+              />
+              <path
+                d="M0.25 15.4167L12.75 5.83333L16.0417 6.25L20.25 0V20H0.25V15.4167Z"
+                fill="#34A853"
+              />
+              <path
+                d="M20.25 20L7.33333 10L5.66667 8.75L20.25 4.58334V20Z"
+                fill="#4285F4"
+              />
+            </svg>
+            Continue with Google
+          </button>
+
+          <button
+            className="social-button"
+            onClick={() => handleSocialLogin("Apple")}
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 21 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.9406 15.3235C17.6524 15.9894 17.3112 16.6024 16.9159 17.1659C16.3771 17.9341 15.9359 18.4659 15.5959 18.7612C15.0688 19.2459 14.5041 19.4941 13.8994 19.5082C13.4653 19.5082 12.9418 19.3847 12.3324 19.1341C11.7209 18.8847 11.1591 18.7612 10.6453 18.7612C10.1065 18.7612 9.52859 18.8847 8.91047 19.1341C8.29141 19.3847 7.79271 19.5153 7.41141 19.5282C6.83153 19.5529 6.25353 19.2977 5.67659 18.7612C5.30835 18.44 4.84776 17.8894 4.296 17.1094C3.704 16.2765 3.21729 15.3106 2.836 14.2094C2.42765 13.02 2.22294 11.8682 2.22294 10.7532C2.22294 9.47589 2.49894 8.37424 3.05176 7.45106C3.48623 6.70953 4.06423 6.12459 4.78765 5.69518C5.51106 5.26577 6.29271 5.04694 7.13447 5.03294C7.59506 5.03294 8.19906 5.17542 8.94965 5.45542C9.69812 5.73636 10.1787 5.87883 10.3894 5.87883C10.5469 5.87883 11.0808 5.71224 11.9859 5.38012C12.8418 5.07212 13.5641 4.94459 14.1559 4.99483C15.7594 5.12424 16.9641 5.75636 17.7653 6.89518C16.3312 7.76412 15.6218 8.98118 15.6359 10.5425C15.6488 11.7586 16.09 12.7706 16.9571 13.5741C17.35 13.9471 17.7888 14.2353 18.2771 14.44C18.1712 14.7471 18.0594 15.0412 17.9406 15.3235ZM14.2629 0.851768C14.2629 1.80494 13.9147 2.69494 13.2206 3.51871C12.3829 4.498 11.3698 5.06389 10.2711 4.97459C10.2563 4.85476 10.249 4.73415 10.2489 4.61342C10.2489 3.69836 10.6473 2.71906 11.3547 1.91836C11.7079 1.51294 12.1571 1.17589 12.7018 0.906945C13.2453 0.642004 13.7594 0.495533 14.2429 0.470474C14.2571 0.597886 14.2629 0.725415 14.2629 0.851768Z"
+                fill="black"
+              />
+            </svg>
+            Continue with Apple
+          </button>
+        </div>
+      </div>
+
+      {/* Botones de navegación originales */}
+      <div className="navigation-buttons">
+        <button onClick={goHome} className="nav-button">
+          Inicio
+        </button>
+        <button
+          onClick={() => goTo("verify_mail")}
+          className="nav-button next-button"
+          disabled={
+            !passwordValidations.minLength ||
+            !passwordValidations.hasThreeRequirements
+          }
+        >
+          Siguiente
+        </button>
+      </div>
+    </div>
+  );
+};
 
 export default SignUp;

--- a/src/SignUp.jsx
+++ b/src/SignUp.jsx
@@ -2,9 +2,11 @@ import React, { useState } from "react";
 import "./SignUp.css";
 
 const SignUp = ({ goTo, goHome }) => {
-  const [email, setEmail] = useState("lopez.vanessa@pucp.pe");
-  const [password, setPassword] = useState("Lc0de#2020");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
+  const [showPasswordTooltip, setShowPasswordTooltip] = useState(false);
 
   // Validaciones de contraseña
   const validatePassword = (password) => {
@@ -24,12 +26,15 @@ const SignUp = ({ goTo, goHome }) => {
 
   const passwordValidations = validatePassword(password);
 
+  // Verificar si el formulario está completo
+  const isFormComplete =
+    email.length > 0 &&
+    passwordValidations.minLength &&
+    passwordValidations.hasThreeRequirements;
+
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (
-      passwordValidations.minLength &&
-      passwordValidations.hasThreeRequirements
-    ) {
+    if (isFormComplete) {
       goTo("verify_mail");
     }
   };
@@ -41,6 +46,29 @@ const SignUp = ({ goTo, goHome }) => {
 
   return (
     <div className="signup-container">
+      {/* Indicador de pasos */}
+      <div className="step-indicator">
+        <div className="step-item active">
+          <div className="step-number">1</div>
+          <div className="step-label">Cuenta</div>
+        </div>
+        <div className="step-divider"></div>
+        <div className="step-item">
+          <div className="step-number">2</div>
+          <div className="step-label">Verificación</div>
+        </div>
+        <div className="step-divider"></div>
+        <div className="step-item">
+          <div className="step-number">3</div>
+          <div className="step-label">Datos</div>
+        </div>
+        <div className="step-divider"></div>
+        <div className="step-item">
+          <div className="step-number">4</div>
+          <div className="step-label">Negocio</div>
+        </div>
+      </div>
+
       <div className="signup-card">
         <div className="signup-header">
           <div className="doctocliq-logo">
@@ -51,6 +79,68 @@ const SignUp = ({ goTo, goHome }) => {
           <p className="signup-subtitle">Sign Up to Doctocliq</p>
         </div>
 
+        {/* Botones sociales primero */}
+        <div className="social-section">
+          <div className="social-title">Continuar con</div>
+          <div className="social-buttons">
+            <button
+              className="social-button"
+              onClick={() => handleSocialLogin("Google")}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 21 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0.25 15.4167V4.58334L7.33333 10L0.25 15.4167Z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M0.25 4.58333L7.33333 10L10.25 7.45833L20.25 5.83333V0H0.25V4.58333Z"
+                  fill="#EA4335"
+                />
+                <path
+                  d="M0.25 15.4167L12.75 5.83333L16.0417 6.25L20.25 0V20H0.25V15.4167Z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M20.25 20L7.33333 10L5.66667 8.75L20.25 4.58334V20Z"
+                  fill="#4285F4"
+                />
+              </svg>
+              Google
+            </button>
+
+            <button
+              className="social-button"
+              onClick={() => handleSocialLogin("Apple")}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 21 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M17.9406 15.3235C17.6524 15.9894 17.3112 16.6024 16.9159 17.1659C16.3771 17.9341 15.9359 18.4659 15.5959 18.7612C15.0688 19.2459 14.5041 19.4941 13.8994 19.5082C13.4653 19.5082 12.9418 19.3847 12.3324 19.1341C11.7209 18.8847 11.1591 18.7612 10.6453 18.7612C10.1065 18.7612 9.52859 18.8847 8.91047 19.1341C8.29141 19.3847 7.79271 19.5153 7.41141 19.5282C6.83153 19.5529 6.25353 19.2977 5.67659 18.7612C5.30835 18.44 4.84776 17.8894 4.296 17.1094C3.704 16.2765 3.21729 15.3106 2.836 14.2094C2.42765 13.02 2.22294 11.8682 2.22294 10.7532C2.22294 9.47589 2.49894 8.37424 3.05176 7.45106C3.48623 6.70953 4.06423 6.12459 4.78765 5.69518C5.51106 5.26577 6.29271 5.04694 7.13447 5.03294C7.59506 5.03294 8.19906 5.17542 8.94965 5.45542C9.69812 5.73636 10.1787 5.87883 10.3894 5.87883C10.5469 5.87883 11.0808 5.71224 11.9859 5.38012C12.8418 5.07212 13.5641 4.94459 14.1559 4.99483C15.7594 5.12424 16.9641 5.75636 17.7653 6.89518C16.3312 7.76412 15.6218 8.98118 15.6359 10.5425C15.6488 11.7586 16.09 12.7706 16.9571 13.5741C17.35 13.9471 17.7888 14.2353 18.2771 14.44C18.1712 14.7471 18.0594 15.0412 17.9406 15.3235ZM14.2629 0.851768C14.2629 1.80494 13.9147 2.69494 13.2206 3.51871C12.3829 4.498 11.3698 5.06389 10.2711 4.97459C10.2563 4.85476 10.249 4.73415 10.2489 4.61342C10.2489 3.69836 10.6473 2.71906 11.3547 1.91836C11.7079 1.51294 12.1571 1.17589 12.7018 0.906945C13.2453 0.642004 13.7594 0.495533 14.2429 0.470474C14.2571 0.597886 14.2629 0.725415 14.2629 0.851768Z"
+                  fill="black"
+                />
+              </svg>
+              Apple
+            </button>
+          </div>
+        </div>
+
+        <div className="divider">
+          <span className="divider-line"></span>
+          <span className="divider-text">O</span>
+          <span className="divider-line"></span>
+        </div>
+
         <form className="signup-form" onSubmit={handleSubmit}>
           <div className="form-group">
             <div className="input-wrapper">
@@ -59,6 +149,7 @@ const SignUp = ({ goTo, goHome }) => {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="form-input"
+                placeholder=" "
                 required
               />
               <label className="floating-label">Email address*</label>
@@ -66,12 +157,17 @@ const SignUp = ({ goTo, goHome }) => {
           </div>
 
           <div className="form-group">
-            <div className="input-wrapper password-wrapper">
+            <div
+              className="input-wrapper password-wrapper"
+              onMouseEnter={() => setShowPasswordTooltip(true)}
+              onMouseLeave={() => setShowPasswordTooltip(false)}
+            >
               <input
                 type={showPassword ? "text" : "password"}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className="form-input"
+                placeholder=" "
                 required
               />
               <label className="floating-label">Password*</label>
@@ -96,137 +192,128 @@ const SignUp = ({ goTo, goHome }) => {
                   />
                 </svg>
               </button>
+
+              {/* Tooltip de validación de contraseña */}
+              {showPasswordTooltip && password.length > 0 && (
+                <div className="password-tooltip">
+                  <div className="tooltip-content">
+                    <p className="tooltip-title">
+                      Tu contraseña debe contener:
+                    </p>
+                    <ul className="tooltip-list">
+                      <li
+                        className={
+                          passwordValidations.minLength ? "valid" : "invalid"
+                        }
+                      >
+                        <span className="checkmark">✓</span>
+                        Al menos 8 caracteres
+                      </li>
+                      <li
+                        className={
+                          passwordValidations.hasThreeRequirements
+                            ? "valid"
+                            : "invalid"
+                        }
+                      >
+                        <span className="checkmark">✓</span>
+                        Al menos 3 de los siguientes:
+                      </li>
+                      <ul className="sub-tooltip-list">
+                        <li
+                          className={
+                            passwordValidations.hasLowercase
+                              ? "valid"
+                              : "invalid"
+                          }
+                        >
+                          <span className="checkmark">✓</span>
+                          Minúsculas (a-z)
+                        </li>
+                        <li
+                          className={
+                            passwordValidations.hasUppercase
+                              ? "valid"
+                              : "invalid"
+                          }
+                        >
+                          <span className="checkmark">✓</span>
+                          Mayúsculas (A-Z)
+                        </li>
+                        <li
+                          className={
+                            passwordValidations.hasNumbers ? "valid" : "invalid"
+                          }
+                        >
+                          <span className="checkmark">✓</span>
+                          Números (0-9)
+                        </li>
+                        <li
+                          className={
+                            passwordValidations.hasSpecialChars
+                              ? "valid"
+                              : "invalid"
+                          }
+                        >
+                          <span className="checkmark">✓</span>
+                          Caracteres especiales (!@#$%^&*)
+                        </li>
+                      </ul>
+                    </ul>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 
-          <div className="password-requirements">
-            <p className="requirements-title">Your password must contain:</p>
-            <ul className="requirements-list">
-              <li
-                className={passwordValidations.minLength ? "valid" : "invalid"}
-              >
-                <span className="checkmark">✓</span>
-                At least 8 characters
-              </li>
-              <li
-                className={
-                  passwordValidations.hasThreeRequirements ? "valid" : "invalid"
-                }
-              >
-                <span className="checkmark">✓</span>
-                At least 3 of the following:
-              </li>
-              <ul className="sub-requirements">
-                <li
-                  className={
-                    passwordValidations.hasLowercase ? "valid" : "invalid"
-                  }
-                >
-                  <span className="checkmark">✓</span>
-                  Lower case letters (a-z)
-                </li>
-                <li
-                  className={
-                    passwordValidations.hasUppercase ? "valid" : "invalid"
-                  }
-                >
-                  <span className="checkmark">✓</span>
-                  Upper case letters (A-Z)
-                </li>
-                <li
-                  className={
-                    passwordValidations.hasNumbers ? "valid" : "invalid"
-                  }
-                >
-                  <span className="checkmark">✓</span>
-                  Numbers (0-9)
-                </li>
-                <li
-                  className={
-                    passwordValidations.hasSpecialChars ? "valid" : "invalid"
-                  }
-                >
-                  <span className="checkmark">✓</span>
-                  Special characters (e.g. !@#$%^&*)
-                </li>
-              </ul>
-            </ul>
+          {/* Checkbox Recuérdame */}
+          <div className="form-group remember-me">
+            <label className="checkbox-wrapper">
+              <input
+                type="checkbox"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                className="checkbox-input"
+              />
+              <span className="checkbox-custom"></span>
+              <span className="checkbox-label">Recuérdame</span>
+            </label>
           </div>
 
           <button
             type="submit"
-            className="continue-button"
-            disabled={
-              !passwordValidations.minLength ||
-              !passwordValidations.hasThreeRequirements
-            }
+            className={`continue-button ${isFormComplete ? "active" : ""}`}
+            disabled={!isFormComplete}
           >
-            Continue
+            {isFormComplete ? (
+              <>
+                <span>Continue</span>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M6 12L10 8L6 4"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </>
+            ) : (
+              "Complete los campos requeridos"
+            )}
           </button>
         </form>
 
         <div className="login-link">
-          <span>Already have an account? </span>
+          <span>¿Ya tienes una cuenta? </span>
           <button className="link-button" onClick={() => goTo("login")}>
-            Log in
-          </button>
-        </div>
-
-        <div className="divider">
-          <span className="divider-line"></span>
-          <span className="divider-text">OR</span>
-          <span className="divider-line"></span>
-        </div>
-
-        <div className="social-buttons">
-          <button
-            className="social-button"
-            onClick={() => handleSocialLogin("Google")}
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 21 20"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M0.25 15.4167V4.58334L7.33333 10L0.25 15.4167Z"
-                fill="#FBBC05"
-              />
-              <path
-                d="M0.25 4.58333L7.33333 10L10.25 7.45833L20.25 5.83333V0H0.25V4.58333Z"
-                fill="#EA4335"
-              />
-              <path
-                d="M0.25 15.4167L12.75 5.83333L16.0417 6.25L20.25 0V20H0.25V15.4167Z"
-                fill="#34A853"
-              />
-              <path
-                d="M20.25 20L7.33333 10L5.66667 8.75L20.25 4.58334V20Z"
-                fill="#4285F4"
-              />
-            </svg>
-            Continue with Google
-          </button>
-
-          <button
-            className="social-button"
-            onClick={() => handleSocialLogin("Apple")}
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 21 20"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M17.9406 15.3235C17.6524 15.9894 17.3112 16.6024 16.9159 17.1659C16.3771 17.9341 15.9359 18.4659 15.5959 18.7612C15.0688 19.2459 14.5041 19.4941 13.8994 19.5082C13.4653 19.5082 12.9418 19.3847 12.3324 19.1341C11.7209 18.8847 11.1591 18.7612 10.6453 18.7612C10.1065 18.7612 9.52859 18.8847 8.91047 19.1341C8.29141 19.3847 7.79271 19.5153 7.41141 19.5282C6.83153 19.5529 6.25353 19.2977 5.67659 18.7612C5.30835 18.44 4.84776 17.8894 4.296 17.1094C3.704 16.2765 3.21729 15.3106 2.836 14.2094C2.42765 13.02 2.22294 11.8682 2.22294 10.7532C2.22294 9.47589 2.49894 8.37424 3.05176 7.45106C3.48623 6.70953 4.06423 6.12459 4.78765 5.69518C5.51106 5.26577 6.29271 5.04694 7.13447 5.03294C7.59506 5.03294 8.19906 5.17542 8.94965 5.45542C9.69812 5.73636 10.1787 5.87883 10.3894 5.87883C10.5469 5.87883 11.0808 5.71224 11.9859 5.38012C12.8418 5.07212 13.5641 4.94459 14.1559 4.99483C15.7594 5.12424 16.9641 5.75636 17.7653 6.89518C16.3312 7.76412 15.6218 8.98118 15.6359 10.5425C15.6488 11.7586 16.09 12.7706 16.9571 13.5741C17.35 13.9471 17.7888 14.2353 18.2771 14.44C18.1712 14.7471 18.0594 15.0412 17.9406 15.3235ZM14.2629 0.851768C14.2629 1.80494 13.9147 2.69494 13.2206 3.51871C12.3829 4.498 11.3698 5.06389 10.2711 4.97459C10.2563 4.85476 10.249 4.73415 10.2489 4.61342C10.2489 3.69836 10.6473 2.71906 11.3547 1.91836C11.7079 1.51294 12.1571 1.17589 12.7018 0.906945C13.2453 0.642004 13.7594 0.495533 14.2429 0.470474C14.2571 0.597886 14.2629 0.725415 14.2629 0.851768Z"
-                fill="black"
-              />
-            </svg>
-            Continue with Apple
+            Iniciar sesión
           </button>
         </div>
       </div>
@@ -239,10 +326,7 @@ const SignUp = ({ goTo, goHome }) => {
         <button
           onClick={() => goTo("verify_mail")}
           className="nav-button next-button"
-          disabled={
-            !passwordValidations.minLength ||
-            !passwordValidations.hasThreeRequirements
-          }
+          disabled={!isFormComplete}
         >
           Siguiente
         </button>


### PR DESCRIPTION
This commit adds a new SignUp component with comprehensive CSS styling.

Changes include:
- New SignUp.css file with 719 lines of styling
- Roboto font import from Google Fonts
- Complete signup form layout with step indicator
- Social login buttons (Google and Apple)
- Form inputs with floating labels and validation
- Password field with show/hide toggle and validation tooltip
- Remember me checkbox with custom styling
- Continue button with active/disabled states
- Navigation buttons and responsive design
- Professional color scheme using primary color #13a688

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/16ff4b7d5a044b4084ef1782fba173df/flare-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>16ff4b7d5a044b4084ef1782fba173df</projectId>-->
<!--<branchName>flare-hub</branchName>-->